### PR TITLE
Fix issues with `idaq64`

### DIFF
--- a/sark/enum.py
+++ b/sark/enum.py
@@ -2,7 +2,7 @@ import idaapi
 from . import exceptions
 from awesome.context import ignored
 
-DEFMASK = 0xFFFFFFFF
+DEFMASK = idaapi.BADADDR
 
 ENUM_ERROR_MAP = {
     idaapi.ENUM_MEMBER_ERROR_NAME:
@@ -339,7 +339,7 @@ class EnumMember(object):
 def _iter_bitmasks(eid):
     """Iterate all bitmasks in a given enum.
 
-    Note that while 0xFFFFFFFF indicates no-more-bitmasks, it is also a
+    Note that while `DEFMASK` indicates no-more-bitmasks, it is also a
     valid bitmask value. The only way to tell if it exists is when iterating
     the serials.
     """
@@ -347,7 +347,7 @@ def _iter_bitmasks(eid):
 
     yield bitmask
 
-    while bitmask != 0xFFFFFFFF:
+    while bitmask != DEFMASK:
         bitmask = idaapi.get_next_bmask(eid, bitmask)
         yield bitmask
 
@@ -355,13 +355,13 @@ def _iter_bitmasks(eid):
 def _iter_enum_member_values(eid, bitmask):
     """Iterate member values with given bitmask inside the enum
 
-    Note that 0xFFFFFFFF can either indicate end-of-values or a valid value.
+    Note that `DEFMASK` can either indicate end-of-values or a valid value.
     Iterate serials to tell apart.
     """
     value = idaapi.get_first_enum_member(eid, bitmask)
 
     yield value
-    while value != 0xFFFFFFFF:
+    while value != DEFMASK:
         value = idaapi.get_next_enum_member(eid, value, bitmask)
         yield value
 

--- a/sark/structure.py
+++ b/sark/structure.py
@@ -71,12 +71,12 @@ def create_struct(name):
         exceptions.SarkCreationFailed:  Struct creation failed
     """
     sid = idc.GetStrucIdByName(name)
-    if sid != 0xFFFFFFFF:
+    if sid != idaapi.BADADDR:
         # The struct already exists.
         raise exceptions.SarkStructAlreadyExists("A struct names {!r} already exists.".format(name))
 
     sid = idc.AddStrucEx(-1, name, 0)
-    if sid == 0xFFFFFFFF:
+    if sid == idaapi.BADADDR:
         raise exceptions.SarkStructCreationFailed("Struct creation failed.")
 
     return sid
@@ -95,7 +95,7 @@ def get_struct(name):
         exceptions.SarkStructNotFound: is the struct does not exist.
     """
     sid = idc.GetStrucIdByName(name)
-    if sid == 0xFFFFFFFF:
+    if sid == idaapi.BADADDR:
         raise exceptions.SarkStructNotFound()
 
     return sid


### PR DESCRIPTION
Explicit use of `0xFFFFFFFF` instead of `idaapi.BADADDR` caused issues on `idaq64`. This is now resolved.