### PR TITLE
Big update

### DIFF
--- a/plugins/autoenum.py
+++ b/plugins/autoenum.py
@@ -1,6 +1,5 @@
 from collections import defaultdict
 import idaapi
-import sys
 import sark
 import idc
 import sark.exceptions
@@ -67,7 +66,7 @@ class AutoEnum(idaapi.plugin_t):
         self._last_enum = enum_name
 
         # Can't ask with negative numbers.
-        if common_value > sys.maxint:
+        if common_value >> ((8 * sark.core.get_native_size()) - 1):
             common_value = 0
 
         const_value = idc.AskLong(common_value, "Const Value")

--- a/plugins/autoenum.py
+++ b/plugins/autoenum.py
@@ -1,5 +1,6 @@
 from collections import defaultdict
 import idaapi
+import sys
 import sark
 import idc
 import sark.exceptions
@@ -64,6 +65,10 @@ class AutoEnum(idaapi.plugin_t):
             enum_name = None
 
         self._last_enum = enum_name
+
+        # Can't ask with negative numbers.
+        if common_value > sys.maxint:
+            common_value = 0
 
         const_value = idc.AskLong(common_value, "Const Value")
         if const_value is None:

--- a/plugins/autostruct.py
+++ b/plugins/autostruct.py
@@ -1,5 +1,6 @@
 import idaapi
 import idc
+
 import sark
 
 
@@ -25,6 +26,11 @@ class AutoStruct(idaapi.plugin_t):
 
     def run(self, arg):
         start, end = sark.get_selection()
+
+        if not sark.structure.selection_has_offsets(start, end):
+            message('No structure offsets in selection. Operation cancelled.')
+            idaapi.warning('No structure offsets in selection. Operation cancelled.')
+            return
 
         struct_name = idc.AskStr(self._prev_struct_name, "Struct Name")
         if not struct_name:

--- a/plugins/function_flow.py
+++ b/plugins/function_flow.py
@@ -2,7 +2,7 @@ import networkx as nx
 
 import idaapi
 
-from sark import get_codeblock, get_flowchart, get_block_start, get_nx_graph
+from sark import CodeBlock, FlowChart, get_block_start, get_nx_graph
 
 try:
     from sark.ui import ActionHandler
@@ -21,7 +21,7 @@ COLOR_EXIT = 0x000048
 
 
 def iter_exit_nodes(ea):
-    for block in get_flowchart(ea):
+    for block in FlowChart(ea):
         # Check if there are successors
         for successor in block.next:
             break
@@ -30,7 +30,7 @@ def iter_exit_nodes(ea):
 
 
 def clear_func(ea):
-    for block in get_flowchart(ea):
+    for block in FlowChart(ea):
         block.color = COLOR_NONE
 
 
@@ -41,9 +41,9 @@ def mark_not_reaching_nodes(ea, source_color=COLOR_SOURCE, other_color=COLOR_NOT
     reaching = nx.descendants(graph, block_ea)
     for node_ea in graph.nodes_iter():
         if node_ea not in reaching:
-            get_codeblock(node_ea).color = other_color
+            CodeBlock(node_ea).color = other_color
 
-    get_codeblock(ea).color = source_color
+    CodeBlock(ea).color = source_color
 
 
 def mark_reaching_nodes(ea, source_color=COLOR_SOURCE, other_color=COLOR_REACHING):
@@ -51,29 +51,29 @@ def mark_reaching_nodes(ea, source_color=COLOR_SOURCE, other_color=COLOR_REACHIN
     graph = graph.reverse()
     block_ea = get_block_start(ea)
     for descendant in nx.descendants(graph, block_ea):
-        get_codeblock(descendant).color = other_color
+        CodeBlock(descendant).color = other_color
 
-    get_codeblock(ea).color = source_color
+    CodeBlock(ea).color = source_color
 
 
 def mark_unreachable_nodes(ea, source_color=COLOR_SOURCE, other_color=COLOR_UNREACHABLE):
     graph = get_nx_graph(ea)
     block_ea = get_block_start(ea)
     descendants = nx.descendants(graph, block_ea)
-    for block in get_flowchart(ea):
+    for block in FlowChart(ea):
         if block.startEA not in descendants:
             block.color = other_color
 
-    get_codeblock(ea).color = source_color
+    CodeBlock(ea).color = source_color
 
 
 def mark_reachable_nodes(ea, source_color=COLOR_SOURCE, other_color=COLOR_REACHABLE):
     graph = get_nx_graph(ea)
     block_ea = get_block_start(ea)
     for descendant in nx.descendants(graph, block_ea):
-        get_codeblock(descendant).color = other_color
+        CodeBlock(descendant).color = other_color
 
-    get_codeblock(ea).color = source_color
+    CodeBlock(ea).color = source_color
 
 
 def mark_exit_nodes(ea, node_color=COLOR_EXIT):

--- a/plugins/highlight_calls.py
+++ b/plugins/highlight_calls.py
@@ -1,0 +1,48 @@
+from awesome.context import ignored
+import idaapi
+import sark
+
+HIGHLIGHT_COLOR = 0x303060
+
+
+@sark.ui.updates_ui
+def highlight_calls_in_function(ea):
+    for line in sark.Function(ea).lines:
+        if not line.insn.is_call:
+            continue
+
+        # Refrain from painting over someone else...
+        if line.color is None:
+            line.color = HIGHLIGHT_COLOR
+
+
+class UiHooks(idaapi.UI_Hooks):
+    def updating_actions(self, ctx):
+        if ctx.form_type == idaapi.BWN_DISASM:
+            with ignored(sark.exceptions.SarkNoFunction):
+                highlight_calls_in_function(ctx.cur_ea)
+
+        return super(UiHooks, self).updating_actions(ctx)
+
+
+class HighlightCalls(idaapi.plugin_t):
+    flags = idaapi.PLUGIN_PROC
+    comment = 'Highlight Call Instructions'
+    help = 'Highlight all call instructions'
+    wanted_name = 'Highlight Calls'
+    wanted_hotkey = ''
+
+    def init(self):
+        self.ui_hooks = UiHooks()
+        self.ui_hooks.hook()
+        return idaapi.PLUGIN_KEEP
+
+    def term(self):
+        self.ui_hooks.unhook()
+
+    def run(self, arg):
+        pass
+
+
+def PLUGIN_ENTRY():
+    return HighlightCalls()

--- a/plugins/ptvsd_enable.py
+++ b/plugins/ptvsd_enable.py
@@ -1,0 +1,29 @@
+import idaapi
+import ptvsd
+
+try:
+    # Enable the debugger. Raises exception if called more than once.
+    ptvsd.enable_attach(secret="IDA")
+except:
+    pass
+
+
+class DebugPlugin(idaapi.plugin_t):
+    flags = idaapi.PLUGIN_FIX
+    comment = "PTVSD Debug Enable"
+    help = "Enable debugging using PTVSD"
+    wanted_name = "PTVSD"
+    wanted_hotkey = ""
+
+    def init(self):
+        return idaapi.PLUGIN_KEEP
+
+    def term(self):
+        pass
+
+    def run(self, arg):
+        pass
+
+
+def PLUGIN_ENTRY():
+    return DebugPlugin()

--- a/sark/__init__.py
+++ b/sark/__init__.py
@@ -48,7 +48,7 @@ if is_in_ida():
     reload(ui)
 
     from .code import *
-    from .codeblocks import get_codeblock, get_nx_graph, get_block_start, get_flowchart
+    from .codeblocks import CodeBlock, get_nx_graph, get_block_start, FlowChart
     from .data import read_ascii_string, get_string
     from .core import set_name, is_function
     from .enum import Enum, enums, add_enum, remove_enum

--- a/sark/code/base.py
+++ b/sark/code/base.py
@@ -5,9 +5,8 @@ import idaapi
 import idc
 import idautils
 
-from ..core import get_func
+from ..core import get_func, get_native_size
 from .. import exceptions
-
 
 NAME_VALID_CHARS = string.ascii_letters + string.digits + "?_:"
 
@@ -52,33 +51,9 @@ def get_register_size(reg_name):
     return get_register_info(reg_name).size
 
 
-def is_reg_in_operand(operand, reg):
-    if not isinstance(reg, int):
-        reg = get_register_id(reg)
-
-    if operand.type == idaapi.o_reg:
-        if operand.reg == reg:
-            return True
-
-    # NOTE: This works for MIPS but was not tested for other archs.
-    elif operand.type == idaapi.o_displ:
-        if operand.reg == reg:
-            return True
-
-    elif operand.type == idaapi.o_phrase:
-        if operand.reg == reg:
-            return True
-
-    return False
-
-
-def is_reg_in_inst(inst, reg_name):
-    reg = get_register_id(reg_name)
-
-    return any(is_reg_in_operand(operand, reg) for operand in inst.Operands)
-
-
-def get_register_name(reg_id, size=4):
+def get_register_name(reg_id, size=None):
+    if size is None:
+        size = get_native_size()
     return idaapi.get_reg_name(reg_id, size)
 
 

--- a/sark/code/function.py
+++ b/sark/code/function.py
@@ -188,9 +188,11 @@ class Function(object):
     @property
     def demangled(self):
         """Return the demangled name of the function. If none exists, return `.name`"""
-        # name = idaapi.demangle_name2(self.name, 0)
-        # This is a hack for 6.6. Should not be the default!
-        name = idaapi.demangle_name(self.name, 0)
+        try:
+            name = idaapi.demangle_name2(self.name, 0)
+        except AttributeError:
+            # Backwards compatibility with IDA 6.6
+            name = idaapi.demangle_name(self.name, 0)
         if name:
             return name
         return self.name

--- a/sark/code/function.py
+++ b/sark/code/function.py
@@ -188,7 +188,9 @@ class Function(object):
     @property
     def demangled(self):
         """Return the demangled name of the function. If none exists, return `.name`"""
-        name = idaapi.demangle_name2(self.name, 0)
+        # name = idaapi.demangle_name2(self.name, 0)
+        # This is a hack for 6.6. Should not be the default!
+        name = idaapi.demangle_name(self.name, 0)
         if name:
             return name
         return self.name

--- a/sark/codeblocks.py
+++ b/sark/codeblocks.py
@@ -1,3 +1,4 @@
+import idc
 import networkx
 
 import idaapi
@@ -21,6 +22,10 @@ class CodeBlock(idaapi.BasicBlock):
         for line in self.lines:
             line.color = color
 
+        node_info = idaapi.node_info_t()
+        node_info.bg_color = color
+        idaapi.set_node_info2(self.startEA, self.id, node_info, idaapi.NIF_BG_COLOR)
+
     @property
     def color(self):
         return next(self.lines).color
@@ -38,13 +43,17 @@ class FlowChart(idaapi.FlowChart):
         return CodeBlock(index, self._q[index], self)
 
 
-def get_flowchart(ea):
+def get_flowchart(ea=None):
+    if ea is None:
+        ea = idaapi.get_screen_ea()
     func = idaapi.get_func(ea)
     flowchart_ = FlowChart(func)
     return flowchart_
 
 
-def get_codeblock(ea):
+def get_codeblock(ea=None):
+    if ea is None:
+        ea = idaapi.get_screen_ea()
     flowchart_ = get_flowchart(ea)
     for code_block in flowchart_:
         if code_block.startEA <= ea < code_block.endEA:

--- a/sark/codeblocks.py
+++ b/sark/codeblocks.py
@@ -3,9 +3,19 @@ import networkx
 
 import idaapi
 from .code import lines
+from .core import get_func
 
 
 class CodeBlock(idaapi.BasicBlock):
+    def __init__(self, id_ea=None, bb=None, fc=None):
+        if bb is None and fc is None:
+            if id_ea is None:
+                id_ea = idaapi.get_screen_ea()
+            temp_codeblock = get_codeblock(id_ea)
+            self.__dict__.update(temp_codeblock.__dict__)
+        else:
+            super(CodeBlock, self).__init__(id=id_ea, bb=bb, fc=fc)
+
     @property
     def lines(self):
         return lines(self.startEA, self.endEA)
@@ -39,6 +49,13 @@ class CodeBlock(idaapi.BasicBlock):
 
 
 class FlowChart(idaapi.FlowChart):
+    def __init__(self, f=None, bounds=None, flags=0):
+        if f is None and bounds is None:
+            f = idaapi.get_screen_ea()
+        if f is not None:
+            f = get_func(f)
+        super(FlowChart, self).__init__(f=f, bounds=bounds, flags=flags)
+
     def _getitem(self, index):
         return CodeBlock(index, self._q[index], self)
 

--- a/sark/core.py
+++ b/sark/core.py
@@ -173,3 +173,9 @@ def is_function(ea):
         return True
     except exceptions.SarkNoFunction:
         return False
+
+
+def is_signed(number, size=None):
+    if not size:
+        size = get_native_size()
+    return number & (1 << ((8 * size) - 1))

--- a/sark/exceptions.py
+++ b/sark/exceptions.py
@@ -200,3 +200,7 @@ class NoFileOffset(SarkError):
 
 class SarkNoString(SarkError):
     pass
+
+
+class OperandNotPhrase(SarkOperandError):
+    pass

--- a/sark/ui.py
+++ b/sark/ui.py
@@ -324,6 +324,7 @@ class NXGraph(idaapi.GraphViewer):
         return handler.on_hint(value, attrs)
 
 # Make sure API is supported to enable use of other functionality in older versions.
+# See http://www.hexblog.com/?p=886
 if idaapi.IDA_SDK_VERSION >= 670:
     class ActionHandler(idaapi.action_handler_t):
         """A wrapper around `idaapi.action_handler_t`.


### PR DESCRIPTION
This is a rather large update to Sark. It includes the following:

1. CodeBlocks API
 1. The `CodeBlock` and `FlowChart` constructors has been improved to match the `Line` constructor. They can now accept `ea` to create on, or be called without arguments to use current `ea`. Usage should change from `get_flowchart(ea)` to `FlowChart(ea)`, and from `get_codeblock(ea)` to `CodeBlock(ea)`.
 1. `CodeBlock.color` now changes the color of the node in the graph overview, as well as the lines of the block.

1. Phrase Operands
 1. Support for phrase operands (`[eax + ebx * 10 + 20]`) was added to the instruction parsing.
 1. Basic testing has been done on x64 and x86 platforms. Other platforms should not be affected.
 1. Access is through the `base`, `index`, `scale` and `offset` (`[base + index * scale + offset]`) fields of the operand object.


1. New Plugins
 1. The `ptvsd.py` plugin from the debugging tutorial was added.
 1. A plugin to highlight `call` lines was added. It only works on IDA6.7 and higher.

1. Support for pre-6.7 versions of IDA was improved. This includes changes in the UI of some plugins, as well as some internal APIs.

1. Bug Fixes
 1. `get_native_size()` now works for 64 bit.


As this is a big update, bugs may arise. I will attempt to close new issues as soon as possible.

Closes #3 .