### PR TITLE
Making sure all the blocks are included in get_nx_graph

### DIFF
--- a/sark/codeblocks.py
+++ b/sark/codeblocks.py
@@ -88,6 +88,9 @@ def get_nx_graph(ea):
     func = idaapi.get_func(ea)
     flowchart = FlowChart(func)
     for block in flowchart:
+        # adding the block as a node is necessary when it has no successors and predecessors
+        nx_graph.add_node(block.startEA)
+
         for pred in block.preds():
             nx_graph.add_edge(pred.startEA, block.startEA)
         for succ in block.succs():


### PR DESCRIPTION
Making sure all the blocks are included in `codeblocks.get_nx_graph`.
fixes #24