### PR TITLE
Fast codeblock iteration

### DIFF
--- a/docs/api/Code-Blocks.rst
+++ b/docs/api/Code-Blocks.rst
@@ -44,6 +44,15 @@ Codeblocks are created using the ``sark.CodeBlock(ea)`` class.
 Flowcharts can be retrieved using the ``sark.FlowChart(ea)``
 class accordingly.
 
+In some cases, you may want to go over more than one function. In those
+cases, you can use the ``sark.codeblocks(start=None, end=None, full=True)`` function.
+The ``full`` parameter controls the way the blocks are generated. With ``full=True``,
+``FlowChart`` objects are generated per function, yielding fully capable ``CodeBlock``
+objects. With ``full=False``, a single ``FlowChart`` is generated for the entire
+address range. This results in faster iteration, but since the blocks are not associated
+to their containing functions, it is not possible to get or set block colors (line color
+will change, though.)
+
 Advanced Usage
 ~~~~~~~~~~~~~~
 

--- a/sark/__init__.py
+++ b/sark/__init__.py
@@ -29,7 +29,7 @@ if is_in_ida():
                    code,
                    exceptions,
                    structure,
-                   codeblocks,
+                   codeblock,
                    data,
                    debug,
                    enum,
@@ -41,14 +41,14 @@ if is_in_ida():
     reload(exceptions)
     reload(graph)
     reload(structure)
-    reload(codeblocks)
+    reload(codeblock)
     reload(data)
     reload(debug)
     reload(enum)
     reload(ui)
 
     from .code import *
-    from .codeblocks import CodeBlock, get_nx_graph, get_block_start, FlowChart, codeblocks
+    from .codeblock import CodeBlock, get_nx_graph, get_block_start, FlowChart, codeblocks
     from .data import read_ascii_string, get_string
     from .core import set_name, is_function
     from .enum import Enum, enums, add_enum, remove_enum

--- a/sark/__init__.py
+++ b/sark/__init__.py
@@ -48,7 +48,7 @@ if is_in_ida():
     reload(ui)
 
     from .code import *
-    from .codeblocks import CodeBlock, get_nx_graph, get_block_start, FlowChart
+    from .codeblocks import CodeBlock, get_nx_graph, get_block_start, FlowChart, codeblocks
     from .data import read_ascii_string, get_string
     from .core import set_name, is_function
     from .enum import Enum, enums, add_enum, remove_enum

--- a/sark/codeblock.py
+++ b/sark/codeblock.py
@@ -1,4 +1,3 @@
-import idc
 import networkx
 
 import idaapi
@@ -112,9 +111,22 @@ def get_nx_graph(ea):
     return nx_graph
 
 
-def codeblocks(start=None, end=None):
-    """Get all `CodeBlock`s in a given range."""
-    start, end = fix_addresses(start, end)
+def codeblocks(start=None, end=None, full=True):
+    """Get all `CodeBlock`s in a given range.
 
-    for code_block in FlowChart(bounds=(start, end)):
-        yield code_block
+    Args:
+        start - start address of the range. If `None` uses IDB start.
+        end - end address of the range. If `None` uses IDB end.
+        full - `True` is required to change node info (e.g. color). `False` causes faster iteration.
+    """
+    if full:
+        for function in functions(start, end):
+            fc = FlowChart(f=function.func_t)
+            for block in fc:
+                yield block
+
+    else:
+        start, end = fix_addresses(start, end)
+
+        for code_block in FlowChart(bounds=(start, end)):
+            yield code_block

--- a/sark/codeblocks.py
+++ b/sark/codeblocks.py
@@ -2,8 +2,8 @@ import idc
 import networkx
 
 import idaapi
-from .code import lines
-from .core import get_func
+from .code import lines, functions
+from .core import get_func, fix_addresses
 
 
 class CodeBlock(idaapi.BasicBlock):
@@ -44,13 +44,13 @@ class CodeBlock(idaapi.BasicBlock):
     def color(self):
         node_info = idaapi.node_info_t()
         success = idaapi.get_node_info2(node_info, self._fc._q.bounds.startEA, self.id)
-        
+
         if not success:
             return None
-            
+
         if not node_info.valid_bg_color():
             return None
-            
+
         return node_info.bg_color
 
     @color.setter
@@ -110,3 +110,11 @@ def get_nx_graph(ea):
             nx_graph.add_edge(block.startEA, succ.startEA)
 
     return nx_graph
+
+
+def codeblocks(start=None, end=None):
+    """Get all `CodeBlock`s in a given range."""
+    start, end = fix_addresses(start, end)
+
+    for code_block in FlowChart(bounds=(start, end)):
+        yield code_block


### PR DESCRIPTION
This patch enables faster codeblock iteration via the `sark.codeblocks` function.

Closes #44