### PR TITLE
use ida_gdl.FC_PREDS in the defaults to get flowchart prev without any special preparation

### DIFF
--- a/sark/codeblock.py
+++ b/sark/codeblock.py
@@ -61,7 +61,7 @@ class CodeBlock(idaapi.BasicBlock):
 
 
 class FlowChart(idaapi.FlowChart):
-    def __init__(self, f=None, bounds=None, flags=0):
+    def __init__(self, f=None, bounds=None, flags=idaapi.FC_PREDS):
         if f is None and bounds is None:
             f = idaapi.get_screen_ea()
         if f is not None:


### PR DESCRIPTION
Sark is great -- my experience of the framework is that it wraps the unexpected IDA behaviour into something with little to no surprises.

I think the Flowchart object could get a small improvement in that regard -- at present .prev() will be empty unless a FlowChart is constructed with the right flags. Setting the flags by default makes the FlowChart object.. less surprising in its behaviour.
