### PR TITLE
meaningful: use get_name_or_address() for non-code xrefs to better di…

### DIFF
--- a/plugins/meaningful.py
+++ b/plugins/meaningful.py
@@ -56,7 +56,7 @@ def show_meaningful_in_function(function):
             # Trim the string for easier display
             string = string[:100]
 
-            idaapi.msg("uncode  0x{:08X}    {}    {}\n".format(xref.frm, sark.core.get_name_or_address(xref.to), repr(string)))
+            idaapi.msg("data    0x{:08X}    {}    {}\n".format(xref.frm, sark.core.get_name_or_address(xref.to), repr(string)))
 
     idaapi.msg("\n\n")
 

--- a/plugins/meaningful.py
+++ b/plugins/meaningful.py
@@ -56,7 +56,7 @@ def show_meaningful_in_function(function):
             # Trim the string for easier display
             string = string[:100]
 
-            idaapi.msg("str     0x{:08X}    0x{:08X}    {}\n".format(xref.frm, xref.to, repr(string)))
+            idaapi.msg("uncode  0x{:08X}    {}    {}\n".format(xref.frm, sark.core.get_name_or_address(xref.to), repr(string)))
 
     idaapi.msg("\n\n")
 


### PR DESCRIPTION
…stinguish between string and other (global) references

When using the meaningful plugin here on some ARMv7 shared libs, I often get 'str' xrefs in the output that are referring not to 'aMeaningfulString' offsets, but rather to 'off_addr' offsets. Using the `sark.core.get_name_or_address()` helps me make sense of these in the output since strings and other offsets are clearly distinguished in the output.

e.g. (now)

```
Meaningful References in 'sub_DEAD' : 0x0000DEAD
Type    Usage         Address       Object
------------------------------------------
uncode  0x0000DEAF    'aNull'    'null'
code    0x0000DECA   0x0000C0D3    strncmp
uncode  0x0000DEED    'off_4773'    '\xfe\xed='
```

(address are completely fake)
