### PR TITLE
Anterior and posterioir comments

### DIFF
--- a/sark/code/idapython_workaround.py
+++ b/sark/code/idapython_workaround.py
@@ -2,7 +2,7 @@ import ida_bytes
 def doExtra(ea):
     """
     the IDA python that was released with IDA 6.95 is missing some functions
-    sepcifically when calling ExtLinB or ExtLinA it throws an exception because it can't find
+    specifically when calling ExtLinB or ExtLinA it throws an exception because it can't find
     the  doExtra function. I took this function from IDA python's  updated github
     https://github.com/idapython
     building idapython  was a huge pain ,so added it here until they distribute an updated binary

--- a/sark/code/idapython_workaround.py
+++ b/sark/code/idapython_workaround.py
@@ -1,0 +1,20 @@
+import ida_bytes
+def doExtra(ea):
+    """
+    the IDA python that was released with IDA 6.95 is missing some functions
+    sepcifically when calling ExtLinB or ExtLinA it throws an exception because it can't find
+    the  doExtra function. I took this function from IDA python's  updated github
+    https://github.com/idapython
+    building idapython  was a huge pain ,so added it here until they distribute an updated binary
+
+    """
+
+    ida_bytes.setFlags(ea, ida_bytes.get_flags_novalue(ea) | ida_bytes.FF_LINE)
+
+def add_doExtra():
+    """
+    ida_bytes.doExtra doesn't exist in the idapython that was distributed with ida 6.95.
+    in case it's not found, we add it
+    """
+    if not hasattr(ida_bytes, 'doExtra'):
+        ida_bytes.doExtra = doExtra

--- a/sark/code/line.py
+++ b/sark/code/line.py
@@ -36,6 +36,7 @@ class Comments(object):
 
          Args:
             cmnt_func: idc.LineA or idc.LineB
+
         Returns:
              The full comment text as string
         """

--- a/sark/code/line.py
+++ b/sark/code/line.py
@@ -15,7 +15,7 @@ class Comments(object):
 
     Provides easy access to all types of comments for an IDA line.
     """
-
+    NONE_THRESHOLD = 2
     def __init__(self, ea):
         self._ea = ea
 
@@ -44,7 +44,17 @@ class Comments(object):
     def anterior(self):
         """Anterior Comment"""
         lines = (idc.LineA(self._ea, index) for index in count())
-        return "\n".join(iter(lines.next, None))
+        final_comment=[]
+        consecutive_none_count =0
+        while consecutive_none_count != self.NONE_THRESHOLD:
+            cmt_lines = list(iter(lines.next, None))
+            if not cmt_lines:
+                consecutive_none_count += 1
+            else:
+                final_comment.extend(cmt_lines)
+                consecutive_none_count = 1
+        return "\n".join(final_comment)
+
 
     @anterior.setter
     @updates_ui

--- a/sark/code/line.py
+++ b/sark/code/line.py
@@ -2,6 +2,7 @@ from itertools import imap, count
 import idaapi
 import idautils
 import idc
+import idapython_workaround
 from ..core import fix_addresses
 from .xref import Xref
 from .instruction import Instruction
@@ -16,8 +17,10 @@ class Comments(object):
     Provides easy access to all types of comments for an IDA line.
     """
     NONE_THRESHOLD = 3
+
     def __init__(self, ea):
         self._ea = ea
+        idapython_workaround.add_doExtra()
 
     def __nonzero__(self):
         return any((self.regular, self.repeat, self.anterior, self.posterior,))

--- a/sark/code/line.py
+++ b/sark/code/line.py
@@ -23,6 +23,15 @@ class Comments(object):
         return any((self.regular, self.repeat, self.anterior, self.posterior,))
 
     def _get_external_comment(self,cmnt_func):
+        """
+        The way to get an anterior or posterior comment  through IDA API is
+        only line by line. The only way to tell when the comment ends is an empty line.
+        if there is an empty line anywhere in an anterior or posterior comment
+        it's treated as None. This function keeps getting lines until there are NONE_THRESHOLD consecutive Nones.
+        That way we can get  comments with some empty lines , without them being cut off.
+        :param cmnt_func: idc.LineA or idc.LineB
+        :return: the full comment text as string
+        """
         lines = (cmnt_func(self._ea, index) for index in count())
         final_comment = []
         consecutive_none_count = 0

--- a/sark/code/line.py
+++ b/sark/code/line.py
@@ -26,14 +26,18 @@ class Comments(object):
         return any((self.regular, self.repeat, self.anterior, self.posterior,))
 
     def _get_external_comment(self,cmnt_func):
-        """
+        """Get anterior or posterior comment
+
         The way to get an anterior or posterior comment  through IDA API is
         only line by line. The only way to tell when the comment ends is an empty line.
         if there is an empty line anywhere in an anterior or posterior comment
         it's treated as None. This function keeps getting lines until there are NONE_THRESHOLD consecutive Nones.
         That way we can get  comments with some empty lines , without them being cut off.
-        :param cmnt_func: idc.LineA or idc.LineB
-        :return: the full comment text as string
+
+         Args:
+            cmnt_func: idc.LineA or idc.LineB
+        Returns:
+             The full comment text as string
         """
         lines = (cmnt_func(self._ea, index) for index in count())
         final_comment = []

--- a/sark/code/line.py
+++ b/sark/code/line.py
@@ -39,10 +39,11 @@ class Comments(object):
             cmt_lines = list(iter(lines.next, None))
             if not cmt_lines:
                 consecutive_none_count += 1
+                final_comment.append("")
             else:
                 final_comment.extend(cmt_lines)
                 consecutive_none_count = 1
-        return "\n".join(final_comment)
+        return ("\n".join(final_comment)).rstrip('\n')
 
     @property
     def regular(self):

--- a/sark/code/line.py
+++ b/sark/code/line.py
@@ -35,7 +35,7 @@ class Comments(object):
         lines = (cmnt_func(self._ea, index) for index in count())
         final_comment = []
         consecutive_none_count = 0
-        while consecutive_none_count != self.NONE_THRESHOLD:
+        while consecutive_none_count < self.NONE_THRESHOLD:
             cmt_lines = list(iter(lines.next, None))
             if not cmt_lines:
                 consecutive_none_count += 1

--- a/sark/code/line.py
+++ b/sark/code/line.py
@@ -42,10 +42,11 @@ class Comments(object):
             cmt_lines = list(iter(lines.next, None))
             if not cmt_lines:
                 consecutive_none_count += 1
-                final_comment.append("")
             else:
                 final_comment.extend(cmt_lines)
                 consecutive_none_count = 1
+            # whenever we reach None , add a new line
+            final_comment.append("")
         return ("\n".join(final_comment)).rstrip('\n')
 
     @property


### PR DESCRIPTION
it's a workaround for 2 issues with posterior and anterior comments 

1. as described in #53  . This solution is using a threshold of Nones, that way you can have up to a certain number of consecutive empty lines that don't end the comment. My assumption was that people  use empty lines in a comment as paragraph separator , so having more than 2 consecutive empty lines is probably unlikely
2. The IDA python that was released with IDA 6.95 is missing some functions. 
  specifically when calling `ExtLinB `or `ExtLinA ` it throws an exception because it can't find
  ida_bytes.doExtra . Meanwhile they released a fix on their [github](https://github.com/idapython) 
  but   building idapython  was a huge pain and I couldn't find updated binaries , so I copied doExtra  from       their code as a workaround until they release the next version. 
  I'm conflicted about this change , but I don't see a convenient way to get the latest version of IDApython and this seemed like a reasonable work around.  