### PR TITLE
Place dt_3byte above dt_byte in DTYP_TO_SIZE

### DIFF
--- a/sark/code/base.py
+++ b/sark/code/base.py
@@ -19,7 +19,6 @@ DTYP_TO_SIZE = {
     idaapi.dt_qword: 8,
     idaapi.dt_byte16: 16,
     idaapi.dt_fword: 6,
-    idaapi.dt_3byte: 3,
     idaapi.dt_byte32: 32,
     idaapi.dt_byte64: 64,
 }


### PR DESCRIPTION
Possible fix for #67 

In IDA 7, dt_3byte and dt_byte are equal. This causes all byte operands
to be listed as size 3.

By placing dt_3byte before dt_byte, we can still
use dt_3byte in IDA versions before 7, but will default to the more
common dt_byte in IDA 7.