### PR TITLE
Update Function.xrefs_from to return self drefs

### DIFF
--- a/sark/code/function.py
+++ b/sark/code/function.py
@@ -160,16 +160,17 @@ class Function(object):
         """Xrefs from the function.
 
         This includes the xrefs from every line in the function, as `Xref` objects.
-        Xrefs are filtered to exclude xrefs that are internal to the function. This
-        means that every xrefs to the function's code will NOT be returned.
-        To get those extra xrefs, you need to iterate the function's lines yourself.
+        Xrefs are filtered to exclude code references that are internal to the function. This
+        means that every xrefs to the function's code will NOT be returned (yet, references
+        to the function's data will be returnd). To get those extra xrefs, you need to iterate
+        the function's lines yourself.
         """
         for line in self.lines:
             for xref in line.xrefs_from:
                 if xref.type.is_flow:
                     continue
 
-                if xref.to in self:
+                if xref.to in self and xref.iscode:
                     continue
 
                 yield xref


### PR DESCRIPTION
Update Function.xrefs_from function to return data references to itself.
This produces a more predictable behavior in the common case when looking for all strings referenced from a function.
The inline documentation is updated accordingly.