### PR TITLE
Compatibility fix between NetworkX 1.x and 2.x versions

### DIFF
--- a/plugins/function_flow.py
+++ b/plugins/function_flow.py
@@ -39,7 +39,13 @@ def mark_not_reaching_nodes(ea, source_color=COLOR_SOURCE, other_color=COLOR_NOT
     graph = graph.reverse()
     block_ea = get_block_start(ea)
     reaching = nx.descendants(graph, block_ea)
-    for node_ea in graph.nodes_iter():
+
+    try:
+        graph_nodes_iter = graph.nodes()
+    except:
+        graph_nodes_iter = graph.nodes_iter()
+
+    for node_ea in graph_nodes_iter:
         if node_ea not in reaching:
             CodeBlock(node_ea).color = other_color
 

--- a/plugins/lca.py
+++ b/plugins/lca.py
@@ -215,11 +215,18 @@ class LCAGraph(idaapi.GraphViewer):
             # This might take a while...
             self.rebuild_graph()
 
-        node_ids = {node: self.AddNode(node) for node in self._lca_graph.nodes_iter()}
+        try:
+            lca_graph_nodes_iter = self._lca_graph.nodes()
+            lca_graph_edges_iter = self._lca_graph.edges()
+        except AttributeError:
+            lca_graph_nodes_iter = self._lca_graph.nodes_iter()
+            lca_graph_edges_iter = self._lca_graph.edges_iter()
+
+        node_ids = {node: self.AddNode(node) for node in lca_graph_nodes_iter}
 
         self._node_ids = node_ids
 
-        for frm, to in self._lca_graph.edges_iter():
+        for frm, to in lca_graph_edges_iter:
             self.AddEdge(node_ids[frm], node_ids[to])
 
         self.color_nodes()

--- a/sark/ui.py
+++ b/sark/ui.py
@@ -314,9 +314,18 @@ class NXGraph(idaapi.GraphViewer):
     def OnRefresh(self):
         self.Clear()
 
-        node_ids = {node: self.AddNode(node) for node in self._graph.nodes_iter()}
+        # Compatibility between NetworkX 1.x and 2.x
+        try:
+            node_ids = {node: self.AddNode(node) for node in self._graph.nodes()}
+        except AttributeError:
+            node_ids = {node: self.AddNode(node) for node in self._graph.nodes_iter()}
 
-        for frm, to in self._graph.edges_iter():
+        try:
+            edges_iter = self._graph.edges()
+        except AttributeError:
+            edges_iter = self._graph.edges_iter()
+
+        for frm, to in edges_iter:
             self.AddEdge(node_ids[frm], node_ids[to])
 
         self.update_node_info()

--- a/sark/ui.py
+++ b/sark/ui.py
@@ -316,16 +316,15 @@ class NXGraph(idaapi.GraphViewer):
 
         # Compatibility between NetworkX 1.x and 2.x
         try:
-            node_ids = {node: self.AddNode(node) for node in self._graph.nodes()}
+            graph_nodes_iter = self._graph.nodes()
+            graph_edges_iter = self._graph.edges()
         except AttributeError:
-            node_ids = {node: self.AddNode(node) for node in self._graph.nodes_iter()}
+            graph_nodes_iter = self._graph.nodes_iter()
+            graph_edges_iter = self._graph.edges_iter()
 
-        try:
-            edges_iter = self._graph.edges()
-        except AttributeError:
-            edges_iter = self._graph.edges_iter()
+        node_ids = {node: self.AddNode(node) for node in graph_nodes_iter}
 
-        for frm, to in edges_iter:
+        for frm, to in graph_edges_iter:
             self.AddEdge(node_ids[frm], node_ids[to])
 
         self.update_node_info()


### PR DESCRIPTION
* NetworkX removed functions nodes_iter() and edges_iter() in preference to nodes() and edges() respectively
* Kept backward compatibility
* Fixes #76 issue