### PR TITLE
Remove PyPI installation option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,11 +22,7 @@ Dependencies
 Installation
 ------------
 
-.. code:: bash
-
-    pip install sark
-
-Or for latest version:
+For latest version:
 
 .. code:: bash
 

--- a/docs/Installation.rst
+++ b/docs/Installation.rst
@@ -4,13 +4,7 @@ Installation
 For Sark Users
 ~~~~~~~~~~~~~~
 
-Sark is now available on PyPI
-
-.. code:: bash
-
-    pip install sark
-
-But if you want to get the bleeding edge version, use:
+To get the bleeding edge version, use:
 
 .. code:: bash
 


### PR DESCRIPTION
It is currently not maintained, and only causing confusion.