### PR TITLE
Updated API calls in plugin_loader.py to match IDA 7.4 API

### DIFF
--- a/plugins/plugin_loader.py
+++ b/plugins/plugin_loader.py
@@ -7,8 +7,8 @@ PLUGINS_LIST = "plugins.list"
 
 USER_PLUGIN_LIST_PATH = os.path.join(idaapi.get_user_idadir(), PLUGINS_LIST)
 SYS_PLUGIN_LIST_PATH = os.path.join(idaapi.idadir(idaapi.CFG_SUBDIR), PLUGINS_LIST)
-if idc.GetIdbPath():
-    PROJECT_PLUGIN_LIST_PATH = os.path.join(os.path.dirname(idc.GetIdbPath()), PLUGINS_LIST)
+if idc.get_idb_path():
+    PROJECT_PLUGIN_LIST_PATH = os.path.join(os.path.dirname(idc.get_idb_path()), PLUGINS_LIST)
 else:
     PROJECT_PLUGIN_LIST_PATH = None
 


### PR DESCRIPTION
Changed the idc.GetIdbPath calls in plugin_loader.py to .idc.get_idb_path to make The Sark Way of loading plugins work with IDA 7.4.