### PR TITLE
Added whitespace check for the plugin_loader paths

### DIFF
--- a/plugins/plugin_loader.py
+++ b/plugins/plugin_loader.py
@@ -36,7 +36,7 @@ def iter_paths(filepath):
         with open(filepath) as f:
             for line in f:
                 # Use `#` for comments
-                if line.startswith("#"):
+                if line.startswith("#") or line.isspace():
                     continue
                 # Remove trailing spaces and newlines, then normalize to avoid duplicates.
                 path = os.path.normpath(line.strip())


### PR DESCRIPTION
The '[PluginLoader] Plugin file not found: .' line when starting ida should not pop up anymore if you have lines of whitespace in your plugins.list files.