### PR TITLE
IDA 7.5 parse_reg_name() compatibility

### DIFF
--- a/sark/code/base.py
+++ b/sark/code/base.py
@@ -36,7 +36,10 @@ def is_ea_call(ea):
 
 def get_register_info(reg_name):
     ri = idaapi.reg_info_t()
-    success = idaapi.parse_reg_name(reg_name, ri)
+    if idaapi.IDA_SDK_VERSION >= 750:
+        success = idaapi.parse_reg_name(ri, reg_name)
+    else:
+        success = idaapi.parse_reg_name(reg_name, ri)
     if not success:
         raise exceptions.SarkInvalidRegisterName("No register named {!r}".format(reg_name))
     return ri


### PR DESCRIPTION
IDA 7.5 changed the order for the arguments of `parse_reg_name`. This PR merely adds a SDK version check to use the proper argument ordering.