### PR TITLE
Fixed sark.core.iter* in IDA 7.5

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -9,6 +9,7 @@ Contributors
 The following people have contributed directly or indirectly to this project:
 
 - `darx0r <https://github.com/darx0r>`_
+- `iamtimmy <https://github.com/iamtimmy>`_
 - `ynvb <https://github.com/ynvb>`_
 - `OfficialMan <https://github.com/OfficialMan>`_
 

--- a/sark/core.py
+++ b/sark/core.py
@@ -69,14 +69,14 @@ def iter_find_query(query, start=None, end=None, down=True):
     start, end = fix_addresses(start, end)
 
     if down:
-        direction = idc.SEARCH_DOWN
+        direction = ida_search.SEARCH_DOWN
     else:
-        direction = idc.SEARCH_UP
+        direction = ida_search.SEARCH_UP
 
-    current = ida_search.find_binary(start, direction, query)
+    current = ida_search.find_binary(start, end, query, 16, direction)
     while current < end:
         yield current
-        current = ida_search.find_binary(current + 1, direction, query)
+        current = ida_search.find_binary(current + 1, end, query, 16, direction)
 
 
 def fix_addresses(start=None, end=None):

--- a/sark/core.py
+++ b/sark/core.py
@@ -1,5 +1,6 @@
 import idaapi
 import idc
+import ida_search
 import string
 from . import exceptions
 
@@ -72,10 +73,10 @@ def iter_find_query(query, start=None, end=None, down=True):
     else:
         direction = idc.SEARCH_UP
 
-    current = idc.FindBinary(start, direction, query)
+    current = ida_search.find_binary(start, direction, query)
     while current < end:
         yield current
-        current = idc.FindBinary(current + 1, direction, query)
+        current = ida_search.find_binary(current + 1, direction, query)
 
 
 def fix_addresses(start=None, end=None):


### PR DESCRIPTION
I swapped from IDA 7.0 to 7.5 today. IDA 7.5 doesn't seem to define idc.FindBinary. I've changed this to the via error/exception messages recommended API