### PR TITLE
fixes to IDA 7.7 deprecation warnings

### DIFF
--- a/sark/code/instruction.py
+++ b/sark/code/instruction.py
@@ -35,7 +35,7 @@ class Phrase(object):
         if self.op_t.type not in (idaapi.o_displ, idaapi.o_phrase):
             raise exceptions.OperandNotPhrase('Operand is not of type o_phrase or o_displ.')
 
-        proc_name = idaapi.get_inf_structure().procName
+        proc_name = idaapi.get_inf_structure().procname
         if proc_name != 'metapc':
             raise exceptions.PhraseProcessorNotSupported(
                 'Phrase analysis not supported for processor {}'.format(proc_name))

--- a/sark/core.py
+++ b/sark/core.py
@@ -93,10 +93,10 @@ def fix_addresses(start=None, end=None):
         (start, end)
     """
     if start in (None, idaapi.BADADDR):
-        start = idaapi.cvar.inf.minEA
+        start = idaapi.cvar.inf.min_ea
 
     if end in (None, idaapi.BADADDR):
-        end = idaapi.cvar.inf.maxEA
+        end = idaapi.cvar.inf.max_ea
 
     return start, end
 


### PR DESCRIPTION
minEA -> min_ea
maxEA -> max_ea
procName -> procname

does not affect 7.5 or 7.6 from my testing.

addresses #102 