### PR TITLE
Bug fixes: UI and graphs

### DIFF
--- a/plugins/autoenum.py
+++ b/plugins/autoenum.py
@@ -78,7 +78,7 @@ class RenameImmediateHandler(idaapi.action_handler_t):
         return 1
 
     def update(self, ctx):
-        if ctx.form_type == idaapi.BWN_DISASM:
+        if ctx.widget_type == idaapi.BWN_DISASM:
             return idaapi.AST_ENABLE_FOR_WIDGET
         return idaapi.AST_DISABLE_FOR_WIDGET
 
@@ -94,7 +94,7 @@ class AutoEnumHandler(idaapi.action_handler_t):
         return 1
 
     def update(self, ctx):
-        if ctx.form_type == idaapi.BWN_DISASM:
+        if ctx.widget_type == idaapi.BWN_DISASM:
             return idaapi.AST_ENABLE_FOR_WIDGET
         return idaapi.AST_DISABLE_FOR_WIDGET
 

--- a/plugins/xrefsgraph.py
+++ b/plugins/xrefsgraph.py
@@ -87,7 +87,7 @@ def show_xref_graph(ea, to=False, distance=4):
 
     call_graph = gen_xref_graph(ea, to=to, distance=distance)
 
-    call_graph.node[ea][sark.ui.NXGraph.BG_COLOR] = 0x80
+    call_graph.nodes[ea][sark.ui.NXGraph.BG_COLOR] = 0x80
 
     title = 'Xrefs {tofrom} {target} '.format(tofrom='to' if to else 'from',
                                               target=_get_best_name(ea))

--- a/sark/ui.py
+++ b/sark/ui.py
@@ -175,7 +175,7 @@ class NXGraph(idaapi.GraphViewer):
         1. By specifying the `handler` parameter to the constructor;
         2. By setting the `NXGraph.HANDLER` attribute of a specific node:
 
-            >>> my_graph.node[my_node][NXGraph.HANDLER] = MyCustomHandler()
+            >>> my_graph.nodes[my_node][NXGraph.HANDLER] = MyCustomHandler()
 
     Two other useful attribute are `NXGraph.BG_COLOR` and `NXGraph.FRAME_COLOR` that allow
     specifying colors for your nodes. If not provided, the default color will be used.
@@ -271,7 +271,7 @@ class NXGraph(idaapi.GraphViewer):
 
     def _get_attrs(self, node_id):
         """Get the node's attributes"""
-        return self._graph.node[self[node_id]]
+        return self._graph.nodes[self[node_id]]
 
     def _get_handling_triplet(self, node_id):
         """_get_handling_triplet(node_id) -> (handler, value, attrs)"""


### PR DESCRIPTION
Update some old APIs:

- ctx.form_type -> ctx.widget_type
- nx.DiGraph.node -> nx.DiGraph.nodes

This fixes both the xrefsgraph and the autoenum plugins.